### PR TITLE
fix for indels in mini bubbles

### DIFF
--- a/src/variants.rs
+++ b/src/variants.rs
@@ -688,7 +688,7 @@ fn path_data_sub_paths<'a, 'b>(
             let from = from_ix.min(to_ix);
             let to = from_ix.max(to_ix);
             let sub_path = &path[from..=to];
-            if sub_path.len() > 2 {
+            if sub_path.len() > 1 {
                 Some((path_ix, sub_path))
             } else {
                 None


### PR DESCRIPTION
Hi Chris,

I hope this can be helpful for your changes and tests.

The little fix concerns the cases in which there is only one node in the bubble, and it involves an indel. In those cases, the subpaths carrying the deletion are 2 node long (start and end nodes) and they were ignored before.

Moreover, I moved the indexes boundaries checks at the end. Surely it can be written better, taking advantage of the `Option` or other peculiarities of Rust, avoiding checking more times `if xxx_ix + 1 < xxx_path.len() && ...`.