### PR TITLE
fixed VFC output format and the variant type classification

### DIFF
--- a/src/variants.rs
+++ b/src/variants.rs
@@ -532,10 +532,13 @@ pub fn detect_variants_against_ref(
             ref_ix += 1;
             query_ix += 1;
         } else {
-            let (next_ref_node, _next_ref_offset, _) = if ref_ix + 1 < ref_path.len() { ref_path[ref_ix + 1] } else { (0, 0, Forward) };
-            let (next_query_node, _next_query_offset, _) = if query_ix + 1 < query_path.len() { query_path[query_ix + 1] } else { (0, 0, Forward) };
+            let ref_path_len = ref_path.len();
+            let query_path_len = query_path.len();
 
-            if ref_ix + 1 < ref_path.len() && next_ref_node == query_node {
+            let (next_ref_node, _next_ref_offset, _) = if ref_ix + 1 < ref_path_len { ref_path[ref_ix + 1] } else { (0, 0, Forward) };
+            let (next_query_node, _next_query_offset, _) = if query_ix + 1 < query_path_len { query_path[query_ix + 1] } else { (0, 0, Forward) };
+
+            if ref_ix + 1 < ref_path_len && next_ref_node == query_node {
                 trace!("Deletion at ref {}\t query {}", ref_ix, query_ix);
                 // Deletion
                 let (prev_ref_node, _prev_ref_offset, _) = if ref_ix == 0 {
@@ -565,7 +568,7 @@ pub fn detect_variants_against_ref(
                 entry.insert(variant);
 
                 ref_ix += 1;
-            } else if query_ix + 1 < query_path.len() && next_query_node == ref_node {
+            } else if query_ix + 1 < query_path_len && next_query_node == ref_node {
                 trace!("Insertion at ref {}\t query {}", ref_ix, query_ix);
                 // Insertion
 
@@ -598,7 +601,7 @@ pub fn detect_variants_against_ref(
 
                 query_ix += 1;
             } else {
-                if ref_ix + 1 >= ref_path.len() || query_ix + 1 >= query_path.len()
+                if ref_ix + 1 >= ref_path_len || query_ix + 1 >= query_path_len
                 {
                     trace!("At end of ref or query");
                     break;

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -130,6 +130,7 @@ pub enum Variant {
     Ins(BString),
     Snv(u8),
     Mnp(BString),
+    Clumped(BString),
 }
 
 impl std::fmt::Display for Variant {
@@ -139,6 +140,7 @@ impl std::fmt::Display for Variant {
             Variant::Ins(b) => write!(f, "Ins({})", b),
             Variant::Snv(b) => write!(f, "Snv({})", char::from(*b)),
             Variant::Mnp(b) => write!(f, "Mnp({})", b),
+            Variant::Clumped(b) => write!(f, "Clumped({})", b),
         }
     }
 }
@@ -825,6 +827,7 @@ pub fn variant_vcf_record(
                         (base_seq, "snv".into())
                     }
                     Variant::Mnp(seq) => (seq.clone(), "mnp".into()),
+                    Variant::Clumped(seq) => (seq.clone(), "clumped".into()),
                 })
                 .unzip();
 

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -644,26 +644,29 @@ pub fn detect_variants_against_ref(
 
                         let prev_ref_seq = segment_sequences.get(&prev_ref_node).unwrap();
                         let last_prev_seq: u8 = *prev_ref_seq.last().unwrap();
-                        let key_ref_seq: BString = std::iter::once(last_prev_seq).collect();
+
+                        let ref_seq_vcf: BString = std::iter::once(last_prev_seq)
+                            .chain(ref_seq.iter().copied())
+                            .collect();
 
                         var_key = VariantKey {
                             ref_name: ref_name.into(),
                             pos: ref_seq_ix - 1,
-                            sequence: key_ref_seq,
+                            sequence: ref_seq_vcf,
                         };
+
+                        let alt_seq_vcf: BString = std::iter::once(last_prev_seq)
+                            .chain(query_seq.iter().copied())
+                            .collect();
 
                         if ref_seq.len() > query_seq.len() {
                             trace!("Deletion at ref {}\t query {}", ref_ix, query_ix);
 
-                            Variant::Del(BString::from(&[last_prev_seq][..]))
+                            Variant::Del(alt_seq_vcf)
                         } else {
                             trace!("Insertion at ref {}\t query {}", ref_ix, query_ix);
 
-                            let var_seq: BString = std::iter::once(last_prev_seq)
-                                .chain(query_seq.iter().copied())
-                                .collect();
-
-                            Variant::Ins(var_seq)
+                            Variant::Ins(alt_seq_vcf)
                         }
                     };
 

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -804,7 +804,9 @@ pub fn detect_variants_in_sub_paths(
                     query_path,
                 );
 
-                ref_map.extend(vars)
+                for (var_key, var_set) in vars {
+                    ref_map.entry(var_key).or_default().extend(var_set);
+                }
             }
         }
 

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -652,7 +652,7 @@ pub fn detect_variants_against_ref(
                             sequence: key_ref_seq,
                         };
 
-                        if ref_seq.len() < query_seq.len() {
+                        if ref_seq.len() > query_seq.len() {
                             trace!("Deletion at ref {}\t query {}", ref_ix, query_ix);
 
                             Variant::Del(BString::from(&[last_prev_seq][..]))

--- a/src/variants/vcf.rs
+++ b/src/variants/vcf.rs
@@ -77,7 +77,7 @@ impl Display for VCFHeader {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let date: DateTime<Utc> = Utc::now();
 
-        writeln!(f, "##fileFormat=VCFv4.2")?;
+        writeln!(f, "##fileformat=VCFv4.2")?;
         writeln!(f, "##fileDate={}", date.format("%Y%m%d"))?;
         writeln!(f, "##reference={}", self.reference.display())?;
 

--- a/src/variants/vcf.rs
+++ b/src/variants/vcf.rs
@@ -83,7 +83,7 @@ impl Display for VCFHeader {
 
         writeln!(
             f,
-            r#"##INFO=<ID=TYPE,Number=A,Type=String,Description="Type of each allele (snv, ins, del, mnp, complex)">"#
+            r#"##INFO=<ID=TYPE,Number=A,Type=String,Description="Type of each allele (snv, ins, del, mnp, clumped)">"#
         )?;
 
         // writeln!(


### PR DESCRIPTION
By identifying variants with `gfa2vcf` in mousy-pangenomes, we are seeing strange results.

In particular, @Flavia95 is preparing some statistics for the variants identified in several mouse pangenomes, but the tools (to work with VCF files) complain. There was just a tiny typo in the header, so the VCF files are valid now. However, in the ouput there are variants classified as MNPs, but they should be INDELs. I changed a bit the variant classification, adding a new curious type too (Clumped).

@Flavia95, could you start retesting on the mouse pangenomes? There are several modifications, and it would be nice to check this PR on bigger pangenomes before merging it in the master.